### PR TITLE
Update linux.mdx修改ubuntu中开机自启命令的问题

### DIFF
--- a/docs/quick-start/deploy/linux.mdx
+++ b/docs/quick-start/deploy/linux.mdx
@@ -88,7 +88,7 @@ echo "deb [ arch=amd64,arm64 ] https://repo.mongodb.org/apt/ubuntu xenial/mongod
 ```bash title="安装 MongoDB"
 sudo apt update
 sudo apt install mongodb-org
-sudo systemctl enable --now mongodb
+sudo systemctl enable --now mongod
 ```
 
 ## ☕ OpenJDK 17


### PR DESCRIPTION
ubuntu mongodb 开机自启命令为
systemctl enable mongod 而不是systemctl enable mongodb